### PR TITLE
Include custbaud.c in Android.mk source files

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -30,7 +30,8 @@ LOCAL_SRC_FILES := \
     term.c \
     fdio.c \
     split.c \
-    termios2.c
+    termios2.c \
+    custbaud.c
 
 LOCAL_CFLAGS += -DVERSION_STR=\"$(VERSION)\"
 


### PR DESCRIPTION
Android build is broken because custbaud.c is not included in the source files in Android.mk